### PR TITLE
Introduce dummy granta lib to have CI pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - export PATH=${HOME}/edm/bin:${PATH}
     - cp edm.yaml $HOME/.edm.yaml
     - edm install -y -e force-bootstrap click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git@0.2.0
     - pushd force-bdss && edm run -e force-bootstrap -- python -m ci build-env --python-version ${PYTHON_VERSION} && popd
     - edm run -e force-bootstrap -- pip install dummy/granta/
     - edm run -e force-bootstrap -- python -m ci install --python-version ${PYTHON_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
     - edm install -y -e force-bootstrap click setuptools
     - git clone -b 0.2.0 git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -e force-bootstrap -- python -m ci build-env --python-version ${PYTHON_VERSION} && popd
-    - edm run -e force-bootstrap -- pip install dummy/granta/
-    - edm run -e force-bootstrap -- python -m ci install --python-version ${PYTHON_VERSION}
+    - edm run -e force-bootstrap -- python -m ci install-dummy-granta --python-version ${PYTHON_VERSION}
 script:
+    - edm run -e force-bootstrap -- python -m ci install --python-version ${PYTHON_VERSION}
     - edm run -e force-bootstrap -- python -m ci flake8 --python-version ${PYTHON_VERSION}
     - edm run -e force-bootstrap -- python -m ci test --python-version ${PYTHON_VERSION}
     - edm run -e force-bootstrap -- python -m ci docs --python-version ${PYTHON_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - export PATH=${HOME}/edm/bin:${PATH}
     - cp edm.yaml $HOME/.edm.yaml
     - edm install -y -e force-bootstrap click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git@0.2.0
+    - git clone -b 0.2.0 git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -e force-bootstrap -- python -m ci build-env --python-version ${PYTHON_VERSION} && popd
     - edm run -e force-bootstrap -- pip install dummy/granta/
     - edm run -e force-bootstrap -- python -m ci install --python-version ${PYTHON_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - edm install -y -e force-bootstrap click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -e force-bootstrap -- python -m ci build-env --python-version ${PYTHON_VERSION} && popd
+    - edm run -e force-bootstrap -- pip install dummy/granta/
     - edm run -e force-bootstrap -- python -m ci install --python-version ${PYTHON_VERSION}
 script:
     - edm run -e force-bootstrap -- python -m ci flake8 --python-version ${PYTHON_VERSION}

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -62,6 +62,7 @@ def install_dummy_granta(python_version):
         "edm", "run", "-e", env_name, "--",
         "pip", "install", "dummmy/granta"])
 
+
 @cli.command(help="Run the tests")
 @python_version_option
 def test(python_version):

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -53,6 +53,15 @@ def install(python_version):
         "pip", "install", "-e", "."])
 
 
+@cli.command(name="install-dummy-granta", help="Installs a dummy version "
+                                               "of the GRANTA library")
+@python_version_option
+def install_dummy_granta(python_version):
+    env_name = get_env_name(python_version)
+    check_call([
+        "edm", "run", "-e", env_name, "--",
+        "pip", "install", "dummmy/granta"])
+
 @cli.command(help="Run the tests")
 @python_version_option
 def test(python_version):

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -60,7 +60,7 @@ def install_dummy_granta(python_version):
     env_name = get_env_name(python_version)
     check_call([
         "edm", "run", "-e", env_name, "--",
-        "pip", "install", "dummmy/granta"])
+        "pip", "install", "dummy/granta"])
 
 
 @cli.command(help="Run the tests")

--- a/dummy/granta/setup.py
+++ b/dummy/granta/setup.py
@@ -1,0 +1,33 @@
+"""Dummy implementation of the granta distribution.
+This is used by the CI to simulate the installation
+of the granta distribution that is not open to release
+"""
+
+import os
+from setuptools import setup, find_packages
+
+VERSION = "0.0.2"
+
+
+# Read description
+with open('README.rst', 'r') as readme:
+    README_TEXT = readme.read()
+
+
+def write_version_py():
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        'granta',
+        'version.py')
+    ver = "__version__ = '{}'\n"
+    with open(filename, 'w') as fh:
+        fh.write(ver.format(VERSION))
+
+
+write_version_py()
+
+setup(
+    name="granta",
+    version=VERSION,
+    packages=find_packages(),
+)

--- a/dummy/granta/setup.py
+++ b/dummy/granta/setup.py
@@ -9,11 +9,6 @@ from setuptools import setup, find_packages
 VERSION = "0.0.2"
 
 
-# Read description
-with open('README.rst', 'r') as readme:
-    README_TEXT = readme.read()
-
-
 def write_version_py():
     filename = os.path.join(
         os.path.dirname(__file__),

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,8 @@ setup(
         ]
     },
     packages=find_packages(),
+    install_requires=[
+        "force_bdss >= 0.2.0",
+        "granta"
+    ]
 )


### PR DESCRIPTION
This PR introduces a dummy granta lib so that the CI can pass. the granta lib is proprietary so we can't have it on the CI build, but we can provide a reasonable dummy implementation so that CI passes.